### PR TITLE
Use withoutMiddleware instead of recommending it

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Support\Facades\Route;
 use StoryChief\StoryChief\Controllers\WebhookController as StoryChiefWebhookController;
 use StoryChief\StoryChief\Middleware\HmacCheckMiddleware as StoryChiefHmacCheckMiddleware;
@@ -8,8 +10,10 @@ Route::post(
   config('statamic.routes.action') . '/StoryChief/webhook',
   [StoryChiefWebhookController::class, 'handle']
 )
-  ->middleware(
-    [
+  ->middleware([
       StoryChiefHmacCheckMiddleware::class,
-    ]
-  );
+  ])
+  ->withoutMiddleware([
+      TrimStrings::class,
+      ConvertEmptyStringsToNull::class  
+  ]);


### PR DESCRIPTION
Rather than recommending it in the documentation, explicitly remove TrimStrings and ConvertEmptyStringsToNull on the Storychief route