### PR TITLE
Statamic3: add support for custom assets containers

### DIFF
--- a/src/FieldHandlers/AssetFieldHandler.php
+++ b/src/FieldHandlers/AssetFieldHandler.php
@@ -48,7 +48,7 @@ class AssetFieldHandler extends BaseFieldHandler
         /** @var \Statamic\Assets\Asset $asset */
         $asset = Asset::make();
         $asset->container($assetContainer);
-        $asset->path('img/sc/'); //Arr::get($this->field->config(),'folder'));
+        $asset->path(ltrim($assetContainer->url(),"/")); // Set it to the disk folder of the container.
 
         $path = $this->createTempFile();
         $uploaded_file = new UploadedFile($path, $this->file_name);
@@ -56,7 +56,7 @@ class AssetFieldHandler extends BaseFieldHandler
 
         $this->deleteTempFile();
 
-        return $asset->url();
+        return $asset->path();
     }
 
     /**


### PR DESCRIPTION
Fix the issue of Statamic 3 not recognising the image path storychief was creating 
Our Addon used a hard coded path to save the images + it returend the assets url `$asset->url()` instead of `$asset->path()`

This PR solves that issue + it adds a small feature of allowing it to work with custom assets containers as we will get the folder name from the container disk now instead of a hard coded path.

# HOW TO TEST: 
1- In your Statamic installation, add an Assets image field to the blueprint that is connected to storychief 
2- publish a story to statamic and verify that the image is attached to your statamic post and is visible in the control panel 

Do the same but with a custom assets container 
- Add a new disk in your `/config/filesystem.yml`
- Add a new assets container in statamic CP => select the disk you just added in you `filesystem.yml`
- Go back to your collection blueprint => update the image field to use the custom container 
- save 
- publish a new post to the site and verify the image works as expected 
- 